### PR TITLE
Redis work generator test

### DIFF
--- a/mirrulations-mocks/src/mirrmock/mock_redis.py
+++ b/mirrulations-mocks/src/mirrmock/mock_redis.py
@@ -1,0 +1,17 @@
+import redis
+
+class BusyRedis():
+    """
+    Stub for testing in place of a Redis server that is busy loading the data to memory, 
+    ping replies with true
+    """
+    def ping(self):
+        raise redis.BusyLoadingError
+
+class ReadyRedis():
+    """
+    Stub for testing in place of an active Redis server, 
+    ping replies with true
+    """
+    def ping(self):
+        return True

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
 
         database = redis.Redis('redis')
         while not is_redis_available(database):
-            print("error")
+            print("Redis database is busy loading")
             time.sleep(30)
 
         job_queue = JobQueue(database)

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -9,6 +9,13 @@ from mirrcore.job_queue import JobQueue
 from mirrcore.data_storage import DataStorage
 
 
+def is_redis_available(database):
+    try:
+        return database.ping()
+    except (ConnectionRefusedError, redis.BusyLoadingError):
+        return False
+
+
 class WorkGenerator:
 
     def __init__(self, job_queue, api, datastorage):
@@ -27,14 +34,6 @@ class WorkGenerator:
 
 
 if __name__ == '__main__':
-
-    def is_redis_available(database):
-        try:
-            # return fakeredis.FakeRedis('localhost').ping() # Not sure if the database is at localhost or 'redis'
-            return database.ping() # Not sure if the database is at localhost or 'redis'
-        except (ConnectionRefusedError, redis.BusyLoadingError) as error:
-            return False
-
     # I wrapped the code in a function to avoid pylint errors
     # about shadowing api and job_queue
     def generate_work():
@@ -42,11 +41,9 @@ if __name__ == '__main__':
         api = RegulationsAPI(os.getenv('API_KEY'))
 
         database = redis.Redis('redis')
-        
         while not is_redis_available(database):
             print("error")
             time.sleep(30)
-
 
         job_queue = JobQueue(database)
 

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -27,15 +27,27 @@ class WorkGenerator:
 
 
 if __name__ == '__main__':
+
+    def is_redis_available(database):
+        try:
+            # return fakeredis.FakeRedis('localhost').ping() # Not sure if the database is at localhost or 'redis'
+            return database.ping() # Not sure if the database is at localhost or 'redis'
+        except (ConnectionRefusedError, redis.BusyLoadingError) as error:
+            return False
+
     # I wrapped the code in a function to avoid pylint errors
     # about shadowing api and job_queue
     def generate_work():
         dotenv.load_dotenv()
         api = RegulationsAPI(os.getenv('API_KEY'))
 
-        # Sleep to allow Redis to come online
-        time.sleep(10)
         database = redis.Redis('redis')
+        
+        while not is_redis_available(database):
+            print("error")
+            time.sleep(30)
+
+
         job_queue = JobQueue(database)
 
         storage = DataStorage()

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -54,3 +54,6 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
     generator.download('documents')
 
     assert len(requests_mock.request_history) == 2
+
+def test_work_generator_retries_redis_connection():
+    database = FakeRedis()

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -55,5 +55,22 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
 
     assert len(requests_mock.request_history) == 2
 
-def test_work_generator_retries_redis_connection():
+def test_when_redis_loading_is_unavailable():
     database = FakeRedis()
+    api = RegulationsAPI('FAKE_KEY')
+    job_queue = JobQueue(database)
+    storage = MockDataStorage()
+    # Missing some kind of way to put fake redis in the loading state
+    generator = WorkGenerator(job_queue, api, storage)
+    is_available = generator.is_redis_available()
+    assert is_available is False
+
+
+def test_when_redis_done_loading_is_available():
+    database = FakeRedis()
+    api = RegulationsAPI('FAKE_KEY')
+    job_queue = JobQueue(database)
+    storage = MockDataStorage()
+    generator = WorkGenerator(job_queue, api, storage)
+    is_available = generator.is_redis_available()
+    assert is_available is True

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -4,6 +4,15 @@ from mirrcore.regulations_api import RegulationsAPI
 from mirrmock.mock_dataset import MockDataSet
 from mirrmock.mock_data_storage import MockDataStorage
 from mirrgen.work_generator import WorkGenerator
+import redis
+
+class BusyRedis():
+    def ping(self):
+        raise redis.BusyLoadingError
+
+class LoadedRedis():
+    def ping(self):
+        return True
 
 
 def test_work_generator_single_page(requests_mock, mocker):
@@ -56,13 +65,13 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
     assert len(requests_mock.request_history) == 2
 
 def test_when_redis_loading_is_unavailable():
-    database = FakeRedis()
+    database = BusyRedis()
     # Missing some kind of way to put fake redis in the loading state
-    is_available = is_redis_available()
+    is_available = is_redis_available(database)
     assert is_available is False
 
 
 def test_when_redis_done_loading_is_available():
-    database = FakeRedis()
-    is_available = is_redis_available()
+    database = LoadedRedis()
+    is_available = is_redis_available(database)
     assert is_available is True

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -3,16 +3,9 @@ from mirrcore.job_queue import JobQueue
 from mirrcore.regulations_api import RegulationsAPI
 from mirrmock.mock_dataset import MockDataSet
 from mirrmock.mock_data_storage import MockDataStorage
+from mirrmock.mock_redis import BusyRedis, ReadyRedis
 from mirrgen.work_generator import WorkGenerator
-import redis
-
-class BusyRedis():
-    def ping(self):
-        raise redis.BusyLoadingError
-
-class LoadedRedis():
-    def ping(self):
-        return True
+from mirrgen.work_generator import is_redis_available
 
 
 def test_work_generator_single_page(requests_mock, mocker):
@@ -64,14 +57,14 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
 
     assert len(requests_mock.request_history) == 2
 
+
 def test_when_redis_loading_is_unavailable():
     database = BusyRedis()
-    # Missing some kind of way to put fake redis in the loading state
     is_available = is_redis_available(database)
     assert is_available is False
 
 
 def test_when_redis_done_loading_is_available():
-    database = LoadedRedis()
+    database = ReadyRedis()
     is_available = is_redis_available(database)
     assert is_available is True

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -57,20 +57,12 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
 
 def test_when_redis_loading_is_unavailable():
     database = FakeRedis()
-    api = RegulationsAPI('FAKE_KEY')
-    job_queue = JobQueue(database)
-    storage = MockDataStorage()
     # Missing some kind of way to put fake redis in the loading state
-    generator = WorkGenerator(job_queue, api, storage)
-    is_available = generator.is_redis_available()
+    is_available = is_redis_available()
     assert is_available is False
 
 
 def test_when_redis_done_loading_is_available():
     database = FakeRedis()
-    api = RegulationsAPI('FAKE_KEY')
-    job_queue = JobQueue(database)
-    storage = MockDataStorage()
-    generator = WorkGenerator(job_queue, api, storage)
-    is_available = generator.is_redis_available()
+    is_available = is_redis_available()
     assert is_available is True


### PR DESCRIPTION
Valeria Matt and I added the is_redis_available() function in work generator. Added tests for if redis is still loading is_redis_available() will catch BusyLoadingError and return False, if it is ready is_redis_available() will return True. mirrmock contains the stubs used in the tests. Work server should be able to reuse most of this code