### PR TITLE
Add devup and devdown scripts to launch and destroy a system with 1 c…

### DIFF
--- a/devdown
+++ b/devdown
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down
+

--- a/devup
+++ b/devup
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose up -d nginx redis mongo work_generator work_server dashboard client1
+


### PR DESCRIPTION
…lient.

In production, our system uses 18 different API keys (work generator and 17
clients), but on our laptop we will only use our personal API key for all
instances.  We only need 1 client running to see whether the system is working,
and these scripts make it easy to launch all the backend and a single client.

`devup` will launch

* nginx
* redis
* mongo
* work_generator
* work_server
* dashboard
* client1

`devdown` will destroy all running containers (it just calls `docker-compose down`)