### PR TITLE
docker-compose startup order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - ./mirrulations-nginx/default.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "80:80"
+    depends_on:
+      - dashboard
   redis:
     image: redis
     volumes:
@@ -22,12 +24,17 @@ services:
     build:
       context: .
       dockerfile: mirrulations-work-generator/Dockerfile
+    depends_on:
+      - redis
+      - mongo
     env_file: env_files/work_gen.env
     restart: always
   work_server:
     build:
       context: .
       dockerfile: mirrulations-work-server/Dockerfile
+    depends_on:
+      - work_generator
     restart: always
     volumes:
       - ~/data/data:/data
@@ -41,101 +48,135 @@ services:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client1.env
     restart: always
   client2:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client2.env
     restart: always
   client3:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client3.env
     restart: always
   client4:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client4.env
     restart: always
   client5:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client5.env
     restart: always
   client6:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client6.env
     restart: always
   client7:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client7.env
     restart: always
   client8:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client8.env
     restart: always
   client9:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client9.env
     restart: always
   client10:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client10.env
     restart: always
   client11:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client11.env
     restart: always
   client12:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client12.env
     restart: always
   client13:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client13.env
     restart: always
   client14:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client14.env
     restart: always
   client15:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client15.env
     restart: always
   client16:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client16.env
     restart: always
   client17:
     build:
       context: .
       dockerfile: mirrulations-client/Dockerfile
+    depends_on:
+      - work_server
     env_file: env_files/client17.env
     restart: always


### PR DESCRIPTION
Adds dependencies to containers to specify the start up order of containers. 

dependency tree:

* branch 1
     * redis and mongo
	     * work_generator
		     * work_server
			     * clients

* branch 2
     * dashboard
	     * nginx
