### PR TITLE
change to estimated document count for speed

### DIFF
--- a/mirrulations-dashboard/src/mirrdash/sum_mongo_counts.py
+++ b/mirrulations-dashboard/src/mirrdash/sum_mongo_counts.py
@@ -31,12 +31,12 @@ def get_done_counts(client, db_name):
 
 
 def get_dockets_count(client, db_name):
-    return int(client[db_name]['dockets'].count_documents({}))
+    return int(client[db_name]['dockets'].estimated_document_count())
 
 
 def get_documents_count(client, db_name):
-    return int(client[db_name]['documents'].count_documents({}))
+    return int(client[db_name]['documents'].estimated_document_count())
 
 
 def get_comments_count(client, db_name):
-    return int(client[db_name]['comments'].count_documents({}))
+    return int(client[db_name]['comments'].estimated_document_count())

--- a/mirrulations-mocks/src/mirrmock/mock_document_count.py
+++ b/mirrulations-mocks/src/mirrmock/mock_document_count.py
@@ -5,9 +5,9 @@ class MockDocumentCount:
     def __init__(self, count_to_return):
         self.count = count_to_return
 
-    def count_documents(self, dummy):
-        assert dummy == {}
+    def estimated_document_count(self):
         return self.count
+
 
 def create_mock_mongodb(docket_count, document_count, comment_count):
     # needs:

--- a/mirrulations-mocks/tests/test_mock_document_count.py
+++ b/mirrulations-mocks/tests/test_mock_document_count.py
@@ -4,6 +4,6 @@ from mirrmock.mock_document_count import create_mock_mongodb
 def test_mock_document_count():
     mock_db = create_mock_mongodb(1, 2, 3)
 
-    assert mock_db['mirrulations']['dockets'].count_documents({}) == 1
-    assert mock_db['mirrulations']['documents'].count_documents({}) == 2
-    assert mock_db['mirrulations']['comments'].count_documents({}) == 3
+    assert mock_db['mirrulations']['dockets'].estimated_document_count() == 1
+    assert mock_db['mirrulations']['documents'].estimated_document_count() == 2
+    assert mock_db['mirrulations']['comments'].estimated_document_count() == 3

--- a/mirrulations-mocks/tests/test_mock_document_count.py
+++ b/mirrulations-mocks/tests/test_mock_document_count.py
@@ -1,6 +1,7 @@
 
 from mirrmock.mock_document_count import create_mock_mongodb
 
+
 def test_mock_document_count():
     mock_db = create_mock_mongodb(1, 2, 3)
 


### PR DESCRIPTION
The first implementation used `count_documents({})`, which has to iterate through all the documents.  This worked in the dev environment where we had a few thousand documents, but it was too slow in production with 17M documents.