### PR TITLE
Add Attachments in Work Server Endpoint

### DIFF
--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -7,18 +7,27 @@ class DataStorage:
         self.dockets = database['dockets']
         self.documents = database['documents']
         self.comments = database['comments']
+        self.attachments = database['attachments']
 
     def exists(self, search_element):
         result_id = search_element['id']
 
         return self.dockets.count_documents({'id': result_id}) > 0 or \
             self.documents.count_documents({'id': result_id}) > 0 or \
-            self.comments.count_documents({'id': result_id}) > 0
+            self.comments.count_documents({'id': result_id}) > 0 or \
+            self.attachments.count_documents({'id': result_id}) > 0
 
     def add(self, data):
-        if data['data']['type'] == 'dockets':
-            self.dockets.insert_one(data)
-        elif data['data']['type'] == 'documents':
-            self.documents.insert_one(data)
-        elif data['data']['type'] == 'comments':
-            self.comments.insert_one(data)
+        if 'type' in data['data'].keys() and 'attachments_text' not in data['data'].keys():
+            if data['data']['type'] == 'dockets':
+                self.dockets.insert_one(data)
+            elif data['data']['type'] == 'documents':
+                self.documents.insert_one(data)
+            elif data['data']['type'] == 'comments':
+                self.comments.insert_one(data)
+        elif 'attachments_text' in data['data'].keys():
+            self.attachments.insert_one(data)
+            # Use this code maybe for inserting multiple attachments 
+            # into different mongo entries:
+            # for i, attachment in enumerate(data['data']['attachments_text']):
+            #     self.attachments.insert_one({'attachment'+str(i):attachment})

--- a/mirrulations-core/tests/test_data_storage.py
+++ b/mirrulations-core/tests/test_data_storage.py
@@ -81,6 +81,25 @@ def test_comment_found_others_not(monkeypatch):
     exists(storage, 'COM-2020-1234')
 
 
+def test_attachment_found_others_not(monkeypatch):
+    storage = DataStorage()
+
+    monkeypatch.setattr(storage, 'dockets', FindOnly('NOTHING'))
+    monkeypatch.setattr(storage, 'documents', FindOnly('NOTHING'))
+    monkeypatch.setattr(storage, 'comments', FindOnly('NOTHING'))
+    monkeypatch.setattr(storage, 'attachments', FindOnly('ATTCH-2020-1234'))
+
+
+    # docket does not exist
+    does_not_exist(storage, 'DOCK-2020-1234')
+
+    # document does not exist
+    does_not_exist(storage, 'DOC-2020-1234')
+
+    # attachment exists
+    exists(storage, 'ATTCH-2020-1234')
+
+
 def test_add_docket(monkeypatch):
 
     storage = DataStorage()

--- a/mirrulations-core/tests/test_data_storage.py
+++ b/mirrulations-core/tests/test_data_storage.py
@@ -34,6 +34,8 @@ def test_docket_found_others_not(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', FindOnly('DOCK-2020-1234'))
     monkeypatch.setattr(storage, 'documents', FindOnly('NOTHING'))
     monkeypatch.setattr(storage, 'comments', FindOnly('NOTHING'))
+    monkeypatch.setattr(storage, 'attachments', FindOnly('NOTHING'))
+
 
     # docket exists
     exists(storage, 'DOCK-2020-1234')
@@ -49,6 +51,8 @@ def test_document_found_others_not(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', FindOnly('NOTHING'))
     monkeypatch.setattr(storage, 'documents', FindOnly('DOC-2020-1234'))
     monkeypatch.setattr(storage, 'comments', FindOnly('NOTHING'))
+    monkeypatch.setattr(storage, 'attachments', FindOnly('NOTHING'))
+
 
     # docket does not exists
     does_not_exist(storage, 'DOCK-2020-1234')
@@ -64,6 +68,8 @@ def test_comment_found_others_not(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', FindOnly('NOTHING'))
     monkeypatch.setattr(storage, 'documents', FindOnly('NOTHING'))
     monkeypatch.setattr(storage, 'comments', FindOnly('COM-2020-1234'))
+    monkeypatch.setattr(storage, 'attachments', FindOnly('NOTHING'))
+
 
     # docket does not exist
     does_not_exist(storage, 'DOCK-2020-1234')
@@ -82,6 +88,8 @@ def test_add_docket(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', MockDB())
     monkeypatch.setattr(storage, 'documents', MockDB())
     monkeypatch.setattr(storage, 'comments', MockDB())
+    monkeypatch.setattr(storage, 'attachments', MockDB())
+
 
     to_insert = {
         'data': {
@@ -95,6 +103,8 @@ def test_add_docket(monkeypatch):
     assert len(storage.dockets.saved) == 1
     assert len(storage.documents.saved) == 0
     assert len(storage.comments.saved) == 0
+    assert len(storage.attachments.saved) == 0
+
 
 
 def test_add_documents(monkeypatch):
@@ -104,6 +114,8 @@ def test_add_documents(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', MockDB())
     monkeypatch.setattr(storage, 'documents', MockDB())
     monkeypatch.setattr(storage, 'comments', MockDB())
+    monkeypatch.setattr(storage, 'attachments', MockDB())
+
 
     to_insert = {
         'data': {
@@ -126,6 +138,8 @@ def test_add_comment(monkeypatch):
     monkeypatch.setattr(storage, 'dockets', MockDB())
     monkeypatch.setattr(storage, 'documents', MockDB())
     monkeypatch.setattr(storage, 'comments', MockDB())
+    monkeypatch.setattr(storage, 'attachments', MockDB())
+
 
     to_insert = {
         'data': {
@@ -139,3 +153,28 @@ def test_add_comment(monkeypatch):
     assert len(storage.dockets.saved) == 0
     assert len(storage.documents.saved) == 0
     assert len(storage.comments.saved) == 1
+
+
+def test_add_attachment(monkeypatch):
+
+    storage = DataStorage()
+
+    monkeypatch.setattr(storage, 'dockets', MockDB())
+    monkeypatch.setattr(storage, 'documents', MockDB())
+    monkeypatch.setattr(storage, 'comments', MockDB())
+    monkeypatch.setattr(storage, 'attachments', MockDB())
+
+
+    to_insert = {
+        'data': {
+            'id': 'COMM-2020-1234',
+            'attachments_text': ['foo']
+        }
+    }
+
+    storage.add(to_insert)
+
+    assert len(storage.dockets.saved) == 0
+    assert len(storage.documents.saved) == 0
+    assert len(storage.comments.saved) == 0
+    assert len(storage.attachments.saved) == 1

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -140,9 +140,10 @@ def create_server(database):
     @workserver.app.route('/post_attachment_results', methods=['post'])
     def _post_attachment_results():
         """
-        This endpoint is hit by a client when it is done with an attachment downloading task.
-        When fully implemented, this function needs to handle the functionallity 
-        of the put_results endpoint (remove job from jobs_in_progress hash and client_jobs) 
+        This endpoint is hit by a client when it is done with an attachment
+        downloading task. When fully implemented, this function needs to
+        handle the functionality of the put_results endpoint
+        (remove job from jobs_in_progress hash and client_jobs)
         and also save the attachments somewhere.
         """
         pass

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -88,10 +88,10 @@ def put_results(workserver, data):
     success, *results = check_results(workserver, data, int(client_id))
     if not success:
         return (success, *results)
-    job_id = data.get('job_id')
+    job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
-    write_results(results[0], data.get('directory'), data.get('results'))
-    workserver.data.add(data.get('results'))
+    write_results(results[0], data['directory'], data['results'])
+    workserver.data.add(data['results'])
     return (True,)
 
 
@@ -110,12 +110,12 @@ def post_attachments(workserver, data):
     success, *results = check_results(workserver, data, int(client_id))
     if not success:
         return (success, *results)
-    job_id = data.get('job_id')
+    job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
     # Code for getting attachment data and saving to mongo goes here
     # Save data to mongo
-    print(data.get('results'))
-    workserver.data.add(data.get('results'))
+    print(data['attachments'])
+    workserver.data.add(data['results'])
     return (True,)
 
 
@@ -171,14 +171,13 @@ def create_server(database):
         and also save the attachments somewhere.
         """
         data = json.loads(request.get_json())
-        if data is None or data.get('results') is None:
+        if data is None or data['results'] is None:
             body = {'error': 'The body does not contain the results'}
             return jsonify(body), 403
         success, *values = post_attachments(workserver, data)
         if not success:
             return tuple(values)
         return jsonify({'success': 'The job was successfully completed'}), 200
-
 
     @workserver.app.route('/get_client_id', methods=['GET'])
     def _get_client_id():

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -137,6 +137,16 @@ def create_server(database):
             return tuple(values)
         return jsonify({'success': 'The job was successfully completed'}), 200
 
+    @workserver.app.route('/post_attachment_results', methods=['post'])
+    def _post_attachment_results():
+        """
+        This endpoint is hit by a client when it is done with an attachment downloading task.
+        When fully implemented, this function needs to handle the functionallity 
+        of the put_results endpoint (remove job from jobs_in_progress hash and client_jobs) 
+        and also save the attachments somewhere.
+        """
+        pass
+
     @workserver.app.route('/get_client_id', methods=['GET'])
     def _get_client_id():
         success, *values = get_client_id(workserver)

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -112,7 +112,9 @@ def post_attachments(workserver, data):
         return (success, *results)
     job_id = data.get('job_id')
     workserver.redis.hdel('jobs_in_progress', job_id)
-    write_results(results[0], data.get('directory'), data.get('results'))
+    # Code for getting attachment data and saving to mongo goes here
+    # Save data to mongo
+    print(data.get('results'))
     workserver.data.add(data.get('results'))
     return (True,)
 
@@ -172,7 +174,9 @@ def create_server(database):
         if data is None or data.get('results') is None:
             body = {'error': 'The body does not contain the results'}
             return jsonify(body), 403
-        
+        success, *values = post_attachments(workserver, data)
+        if not success:
+            return tuple(values)
         return jsonify({'success': 'The job was successfully completed'}), 200
 
 

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -92,7 +92,8 @@ def put_results(workserver, data):
     workserver.redis.hdel('jobs_in_progress', job_id)
     if 'attachments_text' in data['results']['data'].keys():
         print(data['results']['data']['attachments_text'])
-    write_results(results[0], data['directory'], data['results'])
+    else:
+        write_results(results[0], data['directory'], data['results'])
     workserver.data.add(data['results'])
     return (True,)
 

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -90,8 +90,9 @@ def put_results(workserver, data):
         return (success, *results)
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
-    if data.get('attachments'): 
-        print(data.get('attachments'))
+    if 'attachments_text' in data['results']['data'].keys(): 
+        print(data['results']['data']['attachments_text'])
+        workserver.data.add(data['results'])
     write_results(results[0], data['directory'], data['results'])
     workserver.data.add(data['results'])
     return (True,)

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -90,7 +90,7 @@ def put_results(workserver, data):
         return (success, *results)
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
-    if 'attachments_text' in data['results']['data'].keys(): 
+    if 'attachments_text' in data['results']['data'].keys():
         print(data['results']['data']['attachments_text'])
         workserver.data.add(data['results'])
     write_results(results[0], data['directory'], data['results'])

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -92,7 +92,6 @@ def put_results(workserver, data):
     workserver.redis.hdel('jobs_in_progress', job_id)
     if 'attachments_text' in data['results']['data'].keys():
         print(data['results']['data']['attachments_text'])
-        workserver.data.add(data['results'])
     write_results(results[0], data['directory'], data['results'])
     workserver.data.add(data['results'])
     return (True,)

--- a/mirrulations-work-server/tests/test_work_server.py
+++ b/mirrulations-work-server/tests/test_work_server.py
@@ -193,7 +193,7 @@ def test_put_results_returns_correct_attachment_job(mock_server, mocker):
     mock_server.redis.set('total_num_client_ids', 1)
     data = dumps({'job_id': 2, 'directory': 'dir/dir',
                   'results': {'data': {
-                      'attachment_text': ['foo'],
+                      'attachments_text': ['foo'],
                       'type': 'dockets'
                   }}})
     params = {'client_id': 1}

--- a/mirrulations-work-server/tests/test_work_server.py
+++ b/mirrulations-work-server/tests/test_work_server.py
@@ -185,6 +185,25 @@ def test_put_results_returns_correct_job(mock_server, mocker):
     assert len(mock_server.data.added) == 1
 
 
+    def test_put_results_returns_correct_attachment_job(mock_server, mocker):
+
+        mock_write_results(mocker)
+        mock_server.redis.hset('jobs_in_progress', 2, 3)
+        mock_server.redis.hset('client_jobs', 2, 1)
+        mock_server.redis.set('total_num_client_ids', 1)
+        data = dumps({'job_id': 2, 'directory': 'dir/dir',
+                    'results': {'data': {
+                        'type': 'dockets'
+                    }}})
+        params = {'client_id': 1}
+        response = mock_server.client.put('/put_results',
+                                        json=data, query_string=params)
+        assert response.status_code == 200
+        expected = {'success': 'The job was successfully completed'}
+        assert response.get_json() == expected
+        assert len(mock_server.data.added) == 1
+
+
 def test_put_results_returns_500_error_from_regulations(mock_server, mocker):
 
     mock_write_results(mocker)

--- a/mirrulations-work-server/tests/test_work_server.py
+++ b/mirrulations-work-server/tests/test_work_server.py
@@ -185,23 +185,24 @@ def test_put_results_returns_correct_job(mock_server, mocker):
     assert len(mock_server.data.added) == 1
 
 
-    def test_put_results_returns_correct_attachment_job(mock_server, mocker):
+def test_put_results_returns_correct_attachment_job(mock_server, mocker):
 
-        mock_write_results(mocker)
-        mock_server.redis.hset('jobs_in_progress', 2, 3)
-        mock_server.redis.hset('client_jobs', 2, 1)
-        mock_server.redis.set('total_num_client_ids', 1)
-        data = dumps({'job_id': 2, 'directory': 'dir/dir',
-                    'results': {'data': {
-                        'type': 'dockets'
-                    }}})
-        params = {'client_id': 1}
-        response = mock_server.client.put('/put_results',
-                                        json=data, query_string=params)
-        assert response.status_code == 200
-        expected = {'success': 'The job was successfully completed'}
-        assert response.get_json() == expected
-        assert len(mock_server.data.added) == 1
+    mock_write_results(mocker)
+    mock_server.redis.hset('jobs_in_progress', 2, 3)
+    mock_server.redis.hset('client_jobs', 2, 1)
+    mock_server.redis.set('total_num_client_ids', 1)
+    data = dumps({'job_id': 2, 'directory': 'dir/dir',
+                  'results': {'data': {
+                      'attachment_text': ['foo'],
+                      'type': 'dockets'
+                  }}})
+    params = {'client_id': 1}
+    response = mock_server.client.put('/put_results',
+                                      json=data, query_string=params)
+    assert response.status_code == 200
+    expected = {'success': 'The job was successfully completed'}
+    assert response.get_json() == expected
+    assert len(mock_server.data.added) == 1
 
 
 def test_put_results_returns_500_error_from_regulations(mock_server, mocker):


### PR DESCRIPTION
Adding the functionality for the /put_results flask endpoint to accept results from attachment jobs. The body of the message requires client_id as a param and this format for the json:
```
	{"results":{"data":{attachments_text:["words go here"],
				     "type:"attachment"
							}
				 },
	 "job_id": 1
	}
```
The endpoint will verify the job_id is correct, the client_id is valid, and then will save the json to mongo in the Attachments collection.