### PR TITLE
Attachment Text Saved as Separate Mongo Entry

### DIFF
--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -26,6 +26,6 @@ class DataStorage:
             elif data['data']['type'] == 'comments':
                 self.comments.insert_one(data)
         elif 'attachments_text' in data['data'].keys():
-            for attachment in data['data']['attachments_text']:
-                data = {'id':data['data']['id'], 'text':attachment}
+            for attachment_text in data['data']['attachments_text']:
+                data = {'id':data['data']['id'], 'text':attachment_text}
                 self.attachments.insert_one(data)

--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -26,8 +26,6 @@ class DataStorage:
             elif data['data']['type'] == 'comments':
                 self.comments.insert_one(data)
         elif 'attachments_text' in data['data'].keys():
-            self.attachments.insert_one(data)
-            # Use this code maybe for inserting multiple attachments 
-            # into different mongo entries:
-            # for i, attachment in enumerate(data['data']['attachments_text']):
-            #     self.attachments.insert_one({'attachment'+str(i):attachment})
+            for attachment in data['data']['attachments_text']:
+                data = {'id':data['data']['id'], 'text':attachment}
+                self.attachments.insert_one(data)


### PR DESCRIPTION
The data_storage class saves each item in the attachments_text list as a separate entry in mongo as 

```
{id:comment_id, text:"sample_text"}
```