### PR TITLE
Created additional mock tests for Validator() and added timeout argument for put_request

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -154,7 +154,7 @@ class Validator:
         """
         try:
             requests.put(f'{self.url}' + endpoint,
-                         json=dumps(data), params=params)
+                         json=dumps(data), params=params, timeout=10)
 
         except (HTTPError, RequestConnectionError):
             print('There was an error handling this response.')

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -132,7 +132,8 @@ class Validator:
             str response
         """
         try:
-            response = requests.get(f'{self.url}' + endpoint, **kwargs)
+            response = requests.get(f'{self.url}' + endpoint, **kwargs,
+                                    timeout=10)
             response.raise_for_status()
             return response
         except (HTTPError, RequestConnectionError):

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -1,4 +1,3 @@
-from http import server
 import os
 import json
 from pytest import fixture, raises
@@ -178,7 +177,9 @@ def test_mock_get_timeout(mock_requests):
     server_validator = Validator('http://test.com/')
 
     with mock_requests:
-        mock_requests.get('http://test.com/http://test.com/get_results', exc=requests.exceptions.Timeout)
+        mock_requests.get(
+            'http://test.com/http://test.com/get_results',
+            exc=requests.exceptions.Timeout)
         try:
             server_validator.get_request('http://test.com/get_results')
         except requests.exceptions.Timeout as error:
@@ -190,7 +191,9 @@ def test_mock_put_timeout(mock_requests):
     server_validator = Validator('http://test.com/')
 
     with mock_requests:
-        mock_requests.put('http://test.com/http://test.com/put_results?client_id=2001', exc=requests.exceptions.Timeout)
+        mock_requests.put(
+            'http://test.com/http://test.com/put_results?client_id=2001',
+            exc=requests.exceptions.Timeout)
         try:
             server_validator.put_request(
                 'http://test.com/put_results',
@@ -199,7 +202,6 @@ def test_mock_put_timeout(mock_requests):
         except requests.exceptions.Timeout as error:
             print(error)
             print("The connection has timed out")
-
 
 
 def test_client_returns_403_error_to_server(mock_requests):

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -7,6 +7,7 @@ from mirrclient.client import NoJobsAvailableException, Client
 from mirrclient.client import Validator
 from mirrclient.client import is_environment_variables_present
 from mirrclient.client import get_output_path
+from requests.exceptions import Timeout
 
 BASE_URL = 'http://work_server:8080'
 
@@ -178,13 +179,12 @@ def test_mock_get_timeout(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/http://test.com/get_results',
-            exc=requests.exceptions.Timeout)
+            'http://test.com/http://test.com/get_results', exc=Timeout)
         try:
             server_validator.get_request('http://test.com/get_results')
-        except requests.exceptions.Timeout as error:
+        except Timeout as error:
             print(error)
-            print("The connection has timed out")
+            assert isinstance(error, Timeout), "error not a timeout error"
 
 
 def test_mock_put_timeout(mock_requests):
@@ -193,15 +193,15 @@ def test_mock_put_timeout(mock_requests):
     with mock_requests:
         mock_requests.put(
             'http://test.com/http://test.com/put_results?client_id=2001',
-            exc=requests.exceptions.Timeout)
+            exc=Timeout)
         try:
             server_validator.put_request(
                 'http://test.com/put_results',
                 {'job_id': '1'},
                 {'client_id': 2001})
-        except requests.exceptions.Timeout as error:
+        except Timeout as error:
             print(error)
-            print("The connection has timed out")
+            assert isinstance(error, Timeout), "error not a timeout error"
 
 
 def test_client_returns_403_error_to_server(mock_requests):

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -1,3 +1,4 @@
+from http import server
 import os
 import json
 from pytest import fixture, raises
@@ -171,6 +172,34 @@ def test_client_performs_job(mock_requests):
         assert saved_data['attributes'] == {'agencyId': 'NOAA'}
         assert saved_data['id'] == '1'
         assert saved_data['job_type'] == 'documents'
+
+
+def test_mock_get_timeout(mock_requests):
+    server_validator = Validator('http://test.com/')
+
+    with mock_requests:
+        mock_requests.get('http://test.com/http://test.com/get_results', exc=requests.exceptions.Timeout)
+        try:
+            server_validator.get_request('http://test.com/get_results')
+        except requests.exceptions.Timeout as error:
+            print(error)
+            print("The connection has timed out")
+
+
+def test_mock_put_timeout(mock_requests):
+    server_validator = Validator('http://test.com/')
+
+    with mock_requests:
+        mock_requests.put('http://test.com/http://test.com/put_results?client_id=2001', exc=requests.exceptions.Timeout)
+        try:
+            server_validator.put_request(
+                'http://test.com/put_results',
+                {'job_id': '1'},
+                {'client_id': 2001})
+        except requests.exceptions.Timeout as error:
+            print(error)
+            print("The connection has timed out")
+
 
 
 def test_client_returns_403_error_to_server(mock_requests):


### PR DESCRIPTION
Mock tests were created inside test_client.py to test Validator()'s get_request and put_request functions. A timeout argument of 10 seconds was added to the put_request function in order to timeout the user if no connection could be established. 10 seconds provides adequate time to ensure the user can connect.