### PR TITLE
Make work server take more recent jobs from right of job waiting queue

### DIFF
--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -148,7 +148,7 @@ def get_job(workserver):
         return False, values[0], values[1]
     if workserver.redis.llen('jobs_waiting_queue') == 0:
         return False, jsonify({'error': 'No jobs available'}), 403
-    job = json.loads(workserver.redis.lpop('jobs_waiting_queue'))
+    job = json.loads(workserver.redis.rpop('jobs_waiting_queue'))
     job_id = job['job_id']
     url = job['url']
     agency = job['agency'] if job.get('agency') else "other_agency"


### PR DESCRIPTION
The job_queue adds jobs to the front of the job waiting queue. This causes older jobs to be at the front of this list. The work server should pull the newest jobs, meaning the jobs later in the queue. This will allow the software to download the current rules, as requested.